### PR TITLE
Add basic 3D part and plane representations

### DIFF
--- a/daiku/parts/__init__.py
+++ b/daiku/parts/__init__.py
@@ -1,0 +1,7 @@
+"""3‑D part representations used throughout the project."""
+
+from .plane import Plane
+from .part import Part
+
+__all__ = ["Plane", "Part"]
+

--- a/daiku/parts/part.py
+++ b/daiku/parts/part.py
@@ -1,0 +1,84 @@
+"""Representation of three‑dimensional parts.
+
+Parts are the building blocks for higher level assemblies such as doors,
+windows or cabinet boxes.  A part behaves like a six‑sided block by default
+with each face represented by a :class:`~daiku.parts.plane.Plane` instance.
+
+Faces can store 2‑D geometry that describes machining operations; the
+orientation of each face is derived from the size of the part and its origin
+within a global coordinate system.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+from daiku.geo.base import GeoBase, V3D
+from daiku.geo.point import Point
+
+from .plane import Plane
+
+
+@dataclass
+class Part(GeoBase):
+    """A rectangular block shaped part.
+
+    Parameters
+    ----------
+    gid:
+        Identifier for the part.
+    origin:
+        The lower‑left, front corner of the part in 3‑D space.
+    width, height, depth:
+        Dimensions of the part along the X, Y and Z axes respectively.
+    """
+
+    gid: str
+    origin: Point
+    width: float
+    height: float
+    depth: float
+    sides: Dict[str, Plane] = field(init=False)
+
+    def __post_init__(self) -> None:
+        super().__init__(self.gid)
+        self.sides = self._create_sides()
+
+    # ------------------------------------------------------------------
+    # Face helpers
+    # ------------------------------------------------------------------
+    def _create_sides(self) -> Dict[str, Plane]:
+        """Create the six default planes describing this part."""
+
+        o = self.origin
+        w, h, d = self.width, self.height, self.depth
+
+        sides = {
+            "front": Plane(f"{self.gid}_front", o, V3D(0, 0, 1)),
+            "back": Plane(
+                f"{self.gid}_back",
+                Point(f"{self.gid}_back_o", o.x, o.y, o.z + d),
+                V3D(0, 0, -1),
+            ),
+            "left": Plane(f"{self.gid}_left", o, V3D(-1, 0, 0)),
+            "right": Plane(
+                f"{self.gid}_right",
+                Point(f"{self.gid}_right_o", o.x + w, o.y, o.z),
+                V3D(1, 0, 0),
+            ),
+            "bottom": Plane(f"{self.gid}_bottom", o, V3D(0, -1, 0)),
+            "top": Plane(
+                f"{self.gid}_top",
+                Point(f"{self.gid}_top_o", o.x, o.y + h, o.z),
+                V3D(0, 1, 0),
+            ),
+        }
+        return sides
+
+    # Public API -------------------------------------------------------
+    def get_side(self, name: str) -> Plane:
+        """Return one of the part's sides by name."""
+
+        return self.sides[name]
+

--- a/daiku/parts/plane.py
+++ b/daiku/parts/plane.py
@@ -1,0 +1,59 @@
+"""Geometry helpers for part faces.
+
+This module defines a :class:`Plane` that represents a single face of a
+three‑dimensional part.  Each plane stores an origin, a normal and a list of
+2D shapes that describe features on that face (for example cut‑outs or tool
+paths for CNC machining).
+
+The implementation relies on the basic geometry primitives defined under the
+``daiku.geo`` package such as :class:`~daiku.geo.point.Point` and
+``V3D``/``V2D`` vectors.
+"""
+
+from dataclasses import dataclass, field
+from typing import List
+
+from daiku.geo.base import GeoBase, V2D, V3D
+from daiku.geo.point import Point
+
+
+@dataclass
+class Plane(GeoBase):
+    """A single planar face of a part.
+
+    Parameters
+    ----------
+    gid:
+        Identifier for the plane.
+    origin:
+        A point on the plane.  Typically the lower‑left corner of the face in
+        the part's local coordinate system.
+    normal:
+        The outward facing normal vector.
+    shapes:
+        Optional list of 2‑D shapes (each represented as a list of ``V2D``
+        points) that live on this plane.  These shapes can later be translated
+        to CNC tool paths.
+    """
+
+    gid: str
+    origin: Point
+    normal: V3D
+    shapes: List[List[V2D]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        # Initialise GeoBase with the provided identifier.
+        super().__init__(self.gid)
+
+    def add_shape(self, shape: List[V2D]) -> None:
+        """Attach a 2‑D shape to this plane.
+
+        Parameters
+        ----------
+        shape:
+            A sequence of :class:`~daiku.geo.base.V2D` points describing the
+            shape to add.
+        """
+
+        self.shapes.append(shape)
+

--- a/tests/test_part.py
+++ b/tests/test_part.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+# Allow tests to import the project package without installing it.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from daiku.geo.point import Point
+from daiku.parts import Part
+
+
+def test_block_has_six_sides() -> None:
+    part = Part("p1", Point("o", 0, 0, 0), 10.0, 20.0, 30.0)
+
+    assert set(part.sides.keys()) == {
+        "front",
+        "back",
+        "left",
+        "right",
+        "top",
+        "bottom",
+    }
+
+    # Each retrieved side should be a Plane instance
+    for name in part.sides:
+        assert part.get_side(name) is part.sides[name]
+


### PR DESCRIPTION
## Summary
- add `Plane` class for storing face geometry and 2D machining shapes
- implement block-shaped `Part` composed of six default planes
- cover default face generation with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897de6f842483319dbdfb335913bb89