### PR TITLE
Refactor arc configuration compute and add endpoints-based config

### DIFF
--- a/tests/test_arc.py
+++ b/tests/test_arc.py
@@ -8,7 +8,13 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import math
 
 from daiku.geo.base import V3D
-from daiku.geo.arc import Arc, ArcDirection, CenterArcConfig, ThreePointArcConfig
+from daiku.geo.arc import (
+    Arc,
+    ArcDirection,
+    CenterArcConfig,
+    EndpointsArcConfig,
+    ThreePointArcConfig,
+)
 
 
 def test_arc_initializes_components():
@@ -40,3 +46,21 @@ def test_arc_constructed_from_points():
     assert arc.start == start
     assert arc.mid == mid
     assert arc.end == end
+
+
+def test_arc_constructed_from_endpoints_and_radius():
+    start = V3D(1.0, 0.0, 0.0)
+    end = V3D(0.0, 1.0, 0.0)
+    cfg = EndpointsArcConfig(start, end, 1.0, ArcDirection.CCW)
+    arc = Arc("gid", cfg)
+
+    assert math.isclose(arc.center.x, 0.0, abs_tol=1e-9)
+    assert math.isclose(arc.center.y, 0.0, abs_tol=1e-9)
+    assert math.isclose(arc.radius, 1.0, rel_tol=1e-9)
+    assert math.isclose(arc.start_angle, 0.0, abs_tol=1e-9)
+    assert math.isclose(arc.end_angle, math.pi / 2, rel_tol=1e-9)
+    assert arc.direction is ArcDirection.CCW
+    assert arc.start == start
+    assert arc.end == end
+    assert math.isclose(arc.mid.x, math.sqrt(0.5), rel_tol=1e-9)
+    assert math.isclose(arc.mid.y, math.sqrt(0.5), rel_tol=1e-9)


### PR DESCRIPTION
## Summary
- rework `ArcConfig.compute` to fill an `Arc` instance rather than returning data
- add `EndpointsArcConfig` and `Arc.from_endpoints` for start/end points plus radius
- expand tests for new configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68983472384c833191b6ebe02acdfe6f