### PR TITLE
Add part endpoints with nested plane support

### DIFF
--- a/daiku/api.py
+++ b/daiku/api.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.exceptions import HTTPException
+from starlette.routing import Route
+
+from daiku.geo.base import V2D, V3D
+from daiku.geo.point import Point
+from daiku.parts import Part, Plane
+
+# In-memory storage for planes and parts
+planes: Dict[str, Plane] = {}
+parts: Dict[str, Part] = {}
+part_planes: Dict[str, Dict[str, Plane]] = {}
+
+def _v2d(data: dict) -> V2D:
+    return V2D(data["x"], data["y"])
+
+def _v3d(data: dict) -> V3D:
+    return V3D(data["x"], data["y"], data.get("z", 0.0))
+
+def _plane_from_dict(data: dict) -> Plane:
+    o = data["origin"]
+    origin = Point(o["gid"], o["x"], o["y"], o.get("z", 0.0))
+    normal = _v3d(data["normal"])
+    shapes = [[_v2d(p) for p in shape] for shape in data.get("shapes", [])]
+    return Plane(data["gid"], origin, normal, shapes=shapes)
+
+def _plane_to_dict(plane: Plane) -> dict:
+    return {
+        "gid": plane.gid,
+        "origin": {
+            "gid": plane.origin.gid,
+            "x": plane.origin.x,
+            "y": plane.origin.y,
+            "z": plane.origin.z,
+        },
+        "normal": {
+            "x": plane.normal.x,
+            "y": plane.normal.y,
+            "z": plane.normal.z,
+        },
+        "shapes": [[{"x": p.x, "y": p.y} for p in shape] for shape in plane.shapes],
+    }
+
+def _part_from_dict(data: dict) -> Part:
+    o = data["origin"]
+    origin = Point(o["gid"], o["x"], o["y"], o.get("z", 0.0))
+    part = Part(data["gid"], origin, data["width"], data["height"], data["depth"])
+    plane_map: Dict[str, Plane] = {}
+    for p in data.get("planes", []):
+        plane = _plane_from_dict(p)
+        planes[plane.gid] = plane
+        plane_map[plane.gid] = plane
+    part_planes[part.gid] = plane_map
+    return part
+
+def _part_to_dict(part: Part) -> dict:
+    return {
+        "gid": part.gid,
+        "origin": {
+            "gid": part.origin.gid,
+            "x": part.origin.x,
+            "y": part.origin.y,
+            "z": part.origin.z,
+        },
+        "width": part.width,
+        "height": part.height,
+        "depth": part.depth,
+        "planes": [_plane_to_dict(p) for p in part_planes.get(part.gid, {}).values()],
+    }
+
+async def create_plane(request):
+    data = await request.json()
+    plane = _plane_from_dict(data)
+    planes[plane.gid] = plane
+    return JSONResponse(_plane_to_dict(plane))
+
+async def get_plane(request):
+    plane_id = request.path_params["plane_id"]
+    plane = planes.get(plane_id)
+    if plane is None:
+        raise HTTPException(status_code=404, detail="Plane not found")
+    return JSONResponse(_plane_to_dict(plane))
+
+async def create_part(request):
+    data = await request.json()
+    part = _part_from_dict(data)
+    parts[part.gid] = part
+    return JSONResponse(_part_to_dict(part))
+
+async def get_part(request):
+    part_id = request.path_params["part_id"]
+    part = parts.get(part_id)
+    if part is None:
+        raise HTTPException(status_code=404, detail="Part not found")
+    return JSONResponse(_part_to_dict(part))
+
+async def add_part_plane(request):
+    part_id = request.path_params["part_id"]
+    part = parts.get(part_id)
+    if part is None:
+        raise HTTPException(status_code=404, detail="Part not found")
+    data = await request.json()
+    plane = _plane_from_dict(data)
+    planes[plane.gid] = plane
+    part_planes.setdefault(part_id, {})[plane.gid] = plane
+    return JSONResponse(_plane_to_dict(plane))
+
+async def get_part_plane(request):
+    part_id = request.path_params["part_id"]
+    plane_id = request.path_params["plane_id"]
+    part = parts.get(part_id)
+    if part is None:
+        raise HTTPException(status_code=404, detail="Part not found")
+    plane = part_planes.get(part_id, {}).get(plane_id)
+    if plane is None:
+        raise HTTPException(status_code=404, detail="Plane not found for part")
+    return JSONResponse(_plane_to_dict(plane))
+
+routes = [
+    Route("/planes", create_plane, methods=["POST"]),
+    Route("/planes/{plane_id}", get_plane, methods=["GET"]),
+    Route("/components/parts", create_part, methods=["POST"]),
+    Route("/components/parts/{part_id}", get_part, methods=["GET"]),
+    Route("/components/parts/{part_id}/planes", add_part_plane, methods=["POST"]),
+    Route(
+        "/components/parts/{part_id}/planes/{plane_id}",
+        get_part_plane,
+        methods=["GET"],
+    ),
+]
+
+app = Starlette(routes=routes)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 matplotlib<3.10
 numpy==1.23
+starlette
+uvicorn

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,51 @@
+from starlette.testclient import TestClient
+
+from daiku.api import app
+
+client = TestClient(app)
+
+
+def test_create_and_get_plane():
+    payload = {
+        "gid": "plane1",
+        "origin": {"gid": "o1", "x": 0, "y": 0, "z": 0},
+        "normal": {"x": 0, "y": 0, "z": 1},
+        "shapes": [[{"x": 0, "y": 0}, {"x": 1, "y": 1}]],
+    }
+    response = client.post("/planes", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["gid"] == "plane1"
+    assert data["shapes"][0][1]["x"] == 1
+
+    get_resp = client.get("/planes/plane1")
+    assert get_resp.status_code == 200
+    assert get_resp.json() == data
+
+
+def test_create_part_and_add_plane():
+    part_payload = {
+        "gid": "part1",
+        "origin": {"gid": "po", "x": 0, "y": 0, "z": 0},
+        "width": 10.0,
+        "height": 20.0,
+        "depth": 30.0,
+    }
+    part_resp = client.post("/components/parts", json=part_payload)
+    assert part_resp.status_code == 200
+    assert part_resp.json()["gid"] == "part1"
+
+    plane_payload = {
+        "gid": "plane2",
+        "origin": {"gid": "p2", "x": 0, "y": 0, "z": 0},
+        "normal": {"x": 0, "y": 0, "z": 1},
+        "shapes": [],
+    }
+    add_resp = client.post("/components/parts/part1/planes", json=plane_payload)
+    assert add_resp.status_code == 200
+    plane_data = add_resp.json()
+    assert plane_data["gid"] == "plane2"
+
+    get_plane = client.get("/components/parts/part1/planes/plane2")
+    assert get_plane.status_code == 200
+    assert get_plane.json() == plane_data


### PR DESCRIPTION
## Summary
- use existing `daiku.parts` Part and Plane classes for API storage
- serialize planes and parts to/from JSON for nested plane operations
- adjust tests to new plane and part schema

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'starlette')*

------
https://chatgpt.com/codex/tasks/task_e_68997a49326883318fc8bc4fd88d87d8