### PR TITLE
Add Makefile for linting, testing, and dev helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: lint test typecheck ci dev-up dev-down
+
+lint:
+	ruff check daiku tests
+
+test:
+	pytest
+
+typecheck:
+	mypy daiku tests
+
+ci: lint typecheck test
+
+dev-up:
+	docker compose up -d
+
+dev-down:
+	docker compose down


### PR DESCRIPTION
## Summary
- add Makefile targets for linting, type checking, running tests, and Docker-based dev server

## Testing
- `make lint` *(fails: F401 imported but unused)*
- `make typecheck`
- `make test` *(fails: ProxyConnectionError connecting to proxy)*
- `make dev-up` *(fails: docker: No such file or directory)*
- `make dev-down` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ac336b13083319459977437475514